### PR TITLE
Eliminate "division by zero" warnings under Ruby 2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.bundle
 *~
 Makefile
 *.so

--- a/event.c
+++ b/event.c
@@ -233,7 +233,7 @@ static VALUE Event_inspect(VALUE self)
  */
 static VALUE Event_window(VALUE self)
 {
-    VALUE window_id = rb_funcall(self, rb_intern("window_id"), 0, 0);
+    VALUE window_id = rb_funcall(self, rb_intern("window_id"), 0);
     return find_window_by_id(NUM2UINT(window_id));
 }
 

--- a/video.c.m4
+++ b/video.c.m4
@@ -2254,7 +2254,7 @@ static VALUE Surface_pixel_color(VALUE self, VALUE x, VALUE y)
 
 static Uint32 pixel_value(VALUE val, SDL_PixelFormat* format)
 {
-    if (RTEST(rb_funcall(val, rb_intern("integer?"), 0, 0))) {
+    if (RTEST(rb_funcall(val, rb_intern("integer?"), 0))) {
         return NUM2UINT(val);
     } else {
         long len;


### PR DESCRIPTION
Ruby 2.5 seems to have changed how `rb_funcall` is implemented, causing calls with no arguments that pass an explicit null pointer like:
```
rb_funcall(val, rb_intern("integer?"), 0, 0)
```

to show the following warning (at least under MacOS X/clang):

```
video.c:2272:15: warning: division by zero is undefined [-Wdivision-by-zero]
    if (RTEST(rb_funcall(val, rb_intern("integer?"), 0, 0))) {
        ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/ged/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/ruby.h:2470:6: note: expanded from macro 'rb_funcall'
            rb_varargs_argc_check(rb_funcall_argc, rb_funcall_nargs), \
            ^
/Users/ged/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/ruby.h:1775:3: note: expanded from macro 'rb_varargs_argc_check'
         rb_varargs_bad_length(argc, vargc)), \
         ^
/Users/ged/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/ruby.h:1770:56: note: expanded from macro 'rb_varargs_bad_length'
#     define rb_varargs_bad_length(argc, vargc) ((argc)/((argc) == (vargc)))
                                                       ^
/Users/ged/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/ruby.h:452:26: note: expanded from macro 'RTEST'
#define RTEST(v) RB_TEST(v)
                 ~~~~~~~~^~
/Users/ged/.rvm/rubies/ruby-2.5.0/include/ruby-2.5.0/ruby/ruby.h:450:31: note: expanded from macro 'RB_TEST'
#define RB_TEST(v) !(((VALUE)(v) & (VALUE)~RUBY_Qnil) == 0)
                              ^
1 warning generated.
```

The other commit in this PR just ignores `.bundle` files on MacOS X.

Thanks for a great library!