### PR TITLE
Support SDL_mixer >= 2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ ttf.c
 mixer.c
 joystick.c
 gamecontroller.c
+extconf.h
 pkg/
 TAGS
 local/

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,22 @@
 require 'rubygems'
 require 'rubygems/package_task'
+require 'rake/clean'
 require_relative "lib/sdl2/version"
 
 C_M4_FILES = Dir.glob("*.c.m4")
 C_FROM_M4_FILES = C_M4_FILES.map{|path| path.gsub(/\.c\.m4\Z/, ".c") }
 C_FILES = Dir.glob("*.c") | C_FROM_M4_FILES
 RB_FILES = Dir.glob("lib/**/*.rb")
+O_FILES = Rake::FileList[*C_FILES].pathmap('%n.o')
 
 POT_SOURCES = RB_FILES + ["main.c"] + (C_FILES - ["main.c"])
 YARD_SOURCES = "-m markdown --main README.md --files COPYING.txt #{POT_SOURCES.join(" ")}"
 
 WATCH_TARGETS = (C_FILES - C_FROM_M4_FILES) + C_M4_FILES + ["README.md"]
-  
+
+CLEAN.include(O_FILES)
+CLOBBER.include(*C_FROM_M4_FILES)
+
 locale = ENV["YARD_LOCALE"]
 
 def extconf_options

--- a/extconf.rb
+++ b/extconf.rb
@@ -50,4 +50,9 @@ config("SDL2_mixer", "SDL_mixer.h", ["SDL2_mixer", "SDL_mixer"])
 config("SDL2_ttf", "SDL_ttf.h", ["SDL2_ttf", "SDL_ttf"])
 have_header("SDL_filesystem.h")
 
+have_const("MIX_INIT_MODPLUG", "SDL_mixer.h")
+have_const("MIX_INIT_FLUIDSYNTH", "SDL_mixer.h")
+have_const("MIX_INIT_MID", "SDL_mixer.h")
+
+create_header
 create_makefile('sdl2_ext')

--- a/mixer.c.m4
+++ b/mixer.c.m4
@@ -1,5 +1,6 @@
 /* -*- mode: C -*- */
 #ifdef HAVE_SDL_MIXER_H
+#include "extconf.h"
 #include "rubysdl2_internal.h"
 #include <SDL_mixer.h>
 
@@ -1071,14 +1072,23 @@ void rubysdl2_init_mixer(void)
     DEFINE_MIX_INIT(FLAC);
     /* Initialize MOD loader */
     DEFINE_MIX_INIT(MOD);
-    /* Initialize libmodplug */
-    DEFINE_MIX_INIT(MODPLUG);
     /* Initialize MP3 loader */
     DEFINE_MIX_INIT(MP3);
     /* Initialize Ogg vorbis loader */
     DEFINE_MIX_INIT(OGG);
+
+#if HAVE_CONST_MIX_INIT_MODPLUG
+    /* Initialize libmodplug */
+    DEFINE_MIX_INIT(MODPLUG);
+#endif
+#if HAVE_CONST_MIX_INIT_FLUIDSYNTH
     /* Initialize fluidsynth */
     DEFINE_MIX_INIT(FLUIDSYNTH);
+#endif
+#if HAVE_CONST_MIX_INIT_MID
+    /* Initialize mid */
+    DEFINE_MIX_INIT(MID);
+#endif
 
     /* define(`DEFINE_MIX_FORMAT',`rb_define_const(mMixer, "FORMAT_$1", UINT2NUM(AUDIO_$1))') */
     /* Unsiged 8-bit sample format. Used by {Mixer.open} */


### PR DESCRIPTION
This patch adds support for versions of SDL_mixer 2.0.2 and later, which removed the `MIX_INIT_MODPLUG` and `MIX_INIT_FLUIDSYTH` constants, and added `MIX_INIT_MID`.

I implemented this using `have_const` and the `extconf.h` that Mkmf can generate so it'll keep working under earlier versions, but I'm sure there are better ways to do this. I'm not at all familiar with M4, or I'd have attempted to use that instead to follow the project's conventions a bit more closely. 

I also included some Rake tasks for `clean` and `clobber` in a separate commit that made it easier to rebuild it cleanly under various Ruby versions in case they might be useful; you should of course feel free to discard whatever you want from this PR.

Thanks again for a great library!