### PR TITLE
Expose flags that are part of an enum correctly

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -53,6 +53,8 @@ have_header("SDL_filesystem.h")
 have_const("MIX_INIT_MODPLUG", "SDL_mixer.h")
 have_const("MIX_INIT_FLUIDSYNTH", "SDL_mixer.h")
 have_const("MIX_INIT_MID", "SDL_mixer.h")
-
+have_const("SDL_RENDERER_PRESENTVSYNC", "SDL_render.h")
+have_const("SDL_WINDOW_ALLOW_HIGHDPI", "SDL_video.h")
+have_const("SDL_WINDOW_MOUSE_CAPTURE", "SDL_video.h")
 
 create_makefile('sdl2_ext')

--- a/video.c.m4
+++ b/video.c.m4
@@ -2863,11 +2863,11 @@ void rubysdl2_init_video(void)
     DEFINE_WINDOW_FLAGS_CONST(MOUSE_FOCUS);
     /* window is not created by SDL */
     DEFINE_WINDOW_FLAGS_CONST(FOREIGN);
-#ifdef SDL_WINDOW_ALLOW_HIGHDPI
+#ifdef HAVE_CONST_SDL_WINDOW_ALLOW_HIGHDPI
     /* window should be created in high-DPI mode if supported (>= SDL 2.0.1)*/
     DEFINE_WINDOW_FLAGS_CONST(ALLOW_HIGHDPI);
 #endif
-#ifdef SDL_WINDOW_MOSUE_CAPTURE
+#ifdef HAVE_CONST_SDL_WINDOW_MOUSE_CAPTURE
     /* window has mouse caputred (>= SDL 2.0.4) */
     DEFINE_WINDOW_FLAGS_CONST(MOUSE_CAPTURE);
 #endif
@@ -2942,7 +2942,7 @@ void rubysdl2_init_video(void)
     DEFINE_RENDERER_FLAGS_CONST(SOFTWARE);
     /* the renderer uses hardware acceleration */
     DEFINE_RENDERER_FLAGS_CONST(ACCELERATED);
-#ifdef SDL_RENDERER_PRESENTVSYNC
+#ifdef HAVE_CONST_SDL_RENDERER_PRESENTVSYNC
     /* present is synchronized with the refresh rate */
     DEFINE_RENDERER_FLAGS_CONST(PRESENTVSYNC);
 #endif


### PR DESCRIPTION
Some flag symbols I wanted to use exist in my platforms SDL2 headers, but weren't being added to the ruby Flags modules. This change uses extconf.rb to check for symbols instead of using the C preprocessor for this task, The preprocessor check does not find these symbols because they a C symbols, not preprocessor symbols.

These are part of the SDL_RendererFlags or SDL_WindowFlags enum as specified in
  https://wiki.libsdl.org/SDL_RendererFlags
  https://wiki.libsdl.org/SDL_WindowFlags
