### PR TITLE
Fix bugs caught by compiler warnings

### DIFF
--- a/mouse.c
+++ b/mouse.c
@@ -273,7 +273,7 @@ void rubysdl2_init_mouse(void)
     rb_define_singleton_method(cCursor, "shown?", Cursor_s_shown_p, 0);
     rb_define_singleton_method(cCursor, "warp", Cursor_s_warp, 3);
 #if SDL_VERSION_ATLEAST(2,0,4)
-    rb_define_singleton_method(cCursor, "warp_globally", Cursor_s_warp_globally, 3);
+    rb_define_singleton_method(cCursor, "warp_globally", Cursor_s_warp_globally, 2);
 #endif
     
     

--- a/video.c.m4
+++ b/video.c.m4
@@ -3013,7 +3013,7 @@ void rubysdl2_init_video(void)
     rb_define_method(cSurface, "pixel_color", Surface_pixel_color, 2);
     rb_define_method(cSurface, "color_key", Surface_color_key, 0);
     rb_define_method(cSurface, "color_key=", Surface_set_color_key, 1);
-    rb_define_method(cSurface, "unset_color_key", Surface_set_color_key, 0);
+    rb_define_method(cSurface, "unset_color_key", Surface_unset_color_key, 0);
     rb_define_method(cSurface, "pixels", Surface_pixels, 0);
     rb_define_method(cSurface, "pitch", Surface_pitch, 0);
     rb_define_method(cSurface, "bits_per_pixel", Surface_bits_per_pixel, 0);


### PR DESCRIPTION
In two places there seems to be a typo that my compiler uncovered via -Wall. This pull request fixes these two mistakes:

 - SDL2::Cursor::warp_globally is documented as having 2 parameters, but is rb_defined to have 3. Indeed the C function Cursor_s_warp_globally takes 2 parameters (excluding self).
- SDL2::Surface::unset_color_key calls the C function Surface_set_color_key (again with the wrong arity). I assume the C function for unset was what was intended.