### PR TITLE
feat: add SDL2::Renderer#read_pixels

### DIFF
--- a/sample/test_read_pixels.rb
+++ b/sample/test_read_pixels.rb
@@ -1,0 +1,41 @@
+require "sdl2"
+
+SDL2.init(SDL2::INIT_VIDEO|SDL2::INIT_EVENTS)
+
+window = SDL2::Window.create("read_pixels",
+                             SDL2::Window::POS_CENTERED, SDL2::Window::POS_CENTERED,
+                             320, 240, 0)
+renderer = window.create_renderer(-1, 0)
+
+# Draw something
+renderer.draw_color = [0, 128, 255]
+renderer.fill_rect(SDL2::Rect.new(60, 40, 200, 160))
+renderer.draw_color = [255, 255, 0]
+renderer.fill_rect(SDL2::Rect.new(110, 80, 100, 80))
+
+# Capture pixels in ARGB8888 format
+pixels = renderer.read_pixels(nil, SDL2::PixelFormat::ARGB8888)
+
+renderer.present
+
+# Save as BMP
+width, height = 320, 240
+row_size = width * 4
+file_size = 54 + row_size * height
+bmp = String.new(encoding: Encoding::BINARY)
+bmp << ["BM", file_size, 0, 0, 54].pack("A2Vv2V")
+bmp << [40, width, height, 1, 32, 0, 0, 0, 0, 0, 0].pack("VV2v2V6")
+(height - 1).downto(0) {|y| bmp << pixels.byteslice(y * row_size, row_size) }
+File.binwrite("screenshot.bmp", bmp)
+puts "Saved screenshot.bmp (#{File.size("screenshot.bmp")} bytes)"
+
+loop do
+  while ev = SDL2::Event.poll
+    if SDL2::Event::KeyDown === ev && ev.scancode == SDL2::Key::Scan::ESCAPE
+      exit
+    end
+  end
+
+  renderer.present
+  sleep 0.1
+end

--- a/video.c.m4
+++ b/video.c.m4
@@ -1341,6 +1341,54 @@ static VALUE Renderer_present(VALUE self)
 }
 
 /*
+ * @overload read_pixels(rect, format)
+ *   Read pixels from the current rendering target.
+ *
+ *   @param [SDL2::Rect,nil] rect the area to read, or nil for the entire target
+ *   @param [SDL2::PixelFormat,Integer] format the desired pixel format
+ *     (0 to use the format of the rendering target)
+ *   @return [String] raw pixel data as a binary string
+ */
+static VALUE Renderer_read_pixels(VALUE self, VALUE rect, VALUE format)
+{
+    SDL_Renderer* renderer = Get_SDL_Renderer(self);
+    SDL_Rect sdl_rect;
+    SDL_Rect* rect_ptr = NULL;
+    Uint32 fmt = uint32_for_format(format);
+    int w, h, pitch;
+    void* pixels;
+    VALUE result;
+
+    if (rect != Qnil) {
+        sdl_rect = *Get_SDL_Rect(rect);
+        rect_ptr = &sdl_rect;
+        w = sdl_rect.w;
+        h = sdl_rect.h;
+    } else {
+        HANDLE_ERROR(SDL_GetRendererOutputSize(renderer, &w, &h));
+    }
+
+    if (fmt == 0) {
+        SDL_RendererInfo info;
+        HANDLE_ERROR(SDL_GetRendererInfo(renderer, &info));
+        pitch = w * SDL_BYTESPERPIXEL(info.texture_formats[0]);
+    } else {
+        pitch = w * SDL_BYTESPERPIXEL(fmt);
+    }
+
+    pixels = ruby_xmalloc(pitch * h);
+
+    if (SDL_RenderReadPixels(renderer, rect_ptr, fmt, pixels, pitch) < 0) {
+        ruby_xfree(pixels);
+        HANDLE_ERROR(-1);
+    }
+
+    result = rb_str_new(pixels, pitch * h);
+    ruby_xfree(pixels);
+    return result;
+}
+
+/*
  * Crear the rendering target with the drawing color.
  * @return [nil]
  *
@@ -2939,6 +2987,7 @@ void rubysdl2_init_video(void)
     rb_define_method(cRenderer, "copy", Renderer_copy, 3);
     rb_define_method(cRenderer, "copy_ex", Renderer_copy_ex, 6);
     rb_define_method(cRenderer, "present", Renderer_present, 0);
+    rb_define_method(cRenderer, "read_pixels", Renderer_read_pixels, 2);
     rb_define_method(cRenderer, "draw_color",Renderer_draw_color, 0);
     rb_define_method(cRenderer, "draw_color=",Renderer_set_draw_color, 1);
     rb_define_method(cRenderer, "clear", Renderer_clear, 0);


### PR DESCRIPTION
## Summary

Add `SDL2::Renderer#read_pixels` method that wraps `SDL_RenderReadPixels`.

This is a resubmission of #29, addressing the review feedback in https://github.com/ohai/ruby-sdl2/pull/29#issuecomment-4233504492.

## Changes from #29

- **Accepts `SDL2::PixelFormat`**: The `format` parameter now accepts both `SDL2::PixelFormat` and `Integer`, using the existing `uint32_for_format()` helper (consistent with `create_texture` etc.)
- **Respects format=0 semantics**: Passing 0 uses the rendering target's native format as defined by SDL2, instead of overriding it with ARGB8888
- **Sample program included**: `sample/test_read_pixels.rb` demonstrates the method with BMP output

## Usage

```ruby
# Read the entire screen in ARGB8888 format
pixels = renderer.read_pixels(nil, SDL2::PixelFormat::ARGB8888)

# Read a specific area using the rendering target's native format
rect = SDL2::Rect.new(0, 0, 100, 100)
pixels = renderer.read_pixels(rect, 0)
```

## Parameters

- `rect` — `SDL2::Rect` or `nil` (nil reads the entire target)
- `format` — `SDL2::PixelFormat` or `Integer` (0 to use the rendering target's format)

## Returns

Raw pixel data as a binary `String`.

Closes #28
